### PR TITLE
fix(ci): use GH_TOKEN for semantic release

### DIFF
--- a/.github/workflows/_semantic-tag.yml
+++ b/.github/workflows/_semantic-tag.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           set -o pipefail
           npx semantic-release --ci 2>&1 | tee "$RUNNER_TEMP/release.log"

--- a/.github/workflows/_semantic-tag.yml
+++ b/.github/workflows/_semantic-tag.yml
@@ -2,6 +2,9 @@ name: Semantic tag
 
 on:
   workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
       - test
       - test-non-windows
     uses: ./.github/workflows/_semantic-tag.yml
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary
- restore `secrets.GH_TOKEN` in the reusable semantic release workflow
- realign the release auth path with `./tmp/replace-tokens-action`
- avoid the default Actions token path that was rejected by the repository ruleset on `main`

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `npx prettier --check .github/workflows/*.yml`
- confirmed `GH_TOKEN` repo secret exists
- confirmed the active ruleset requires PRs on `main` and the current user can bypass, which matches the intended PAT-based release flow