### PR TITLE
ci: rename update-main-version workflow to update-major-tag

### DIFF
--- a/.github/workflows/update-major-tag.yml
+++ b/.github/workflows/update-major-tag.yml
@@ -1,6 +1,6 @@
-name: update main version
+name: Update major tag
 
-# Re-tags the latest main version, using the latest tag's major version
+# Re-tags the latest release with its moving major tag
 # Examples: `v1.2.0 -> v1` or `v2.9.0 -> v2`
 # Triggers: after a release is published, or manually dispatched
 # Similar to: https://github.com/actions/checkout/blob/main/.github/workflows/update-main-version.yml
@@ -18,7 +18,7 @@ on:
         required: true
       version:
         description: |
-          The major version to update. Example: v1
+          The major tag to update. Example: v1
         required: true
         default: 'v1'
 
@@ -33,8 +33,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  update-main-version:
-    name: Update main version
+  update-major-tag:
+    name: Update major tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -48,7 +48,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "226837+jonlabelle@users.noreply.github.com"
 
-      - name: Auto-tag latest major version with ${{ env.TARGET }}
+      - name: Auto-update major tag with ${{ env.TARGET }}
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           if [[ "${TARGET}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -56,7 +56,7 @@ jobs:
             if [[ "${TARGET}" != "${MAJOR_VER}" ]]; then
               git tag -f "${MAJOR_VER}" "${TARGET}"
               git push origin "${MAJOR_VER}" --force
-              echo "::notice title=Main version tagged::Tagged ${TARGET} with ${MAJOR_VER}"
+              echo "::notice title=Major tag updated::Tagged ${TARGET} with ${MAJOR_VER}"
             else
               echo "::warning title=Already tagged::Target is already tagged with ${MAJOR_VER}. Nothing to do."
               exit 1
@@ -78,4 +78,4 @@ jobs:
           MAJOR_VER: ${{ github.event.inputs.version }}
         run: |
           git push origin "${MAJOR_VER}" --force
-          echo "::notice title=Main version tagged::Tagged ${TARGET} with ${MAJOR_VER}"
+          echo "::notice title=Major tag updated::Tagged ${TARGET} with ${MAJOR_VER}"


### PR DESCRIPTION
Rename the workflow from `update-main-version.yml` to `update-major-tag.yml` and align its labels with its actual purpose of maintaining the moving major tag, such as `v1`.

No behavior changes are intended.

Ported from jonlabelle/replace-tokens-action#22.