### PR TITLE
fix: write GitHub path files as UTF-8 without BOM in PowerShell fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,11 +20,15 @@ runs:
       id: ssis-tools
       run: |
         $toolsPath = Join-Path -Path '${{ github.action_path }}' -ChildPath 'ssis-tools'
-        Write-Output "ssis_tools_path=$toolsPath" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8NoBOM -Append
+        [System.IO.File]::AppendAllText($env:GITHUB_OUTPUT, "ssis_tools_path=$toolsPath$([Environment]::NewLine)", [System.Text.UTF8Encoding]::new($false))
 
     - name: Download SSISDevOpsTools.exe
       shell: pwsh
-      run: Invoke-WebRequest -Uri https://aka.ms/SSISDevOpsTools -OutFile SSISDevOpsTools.exe -ErrorAction 'Stop'
+      run: >-
+        Invoke-WebRequest
+        -Uri https://aka.ms/SSISDevOpsTools
+        -OutFile SSISDevOpsTools.exe
+        -ErrorAction 'Stop'
 
     - name: Extract SSISDevOpsTools.exe
       shell: pwsh
@@ -34,4 +38,9 @@ runs:
 
     - name: Add SSIS tools path to system path
       shell: pwsh
-      run: Write-Output "${{ steps.ssis-tools.outputs.ssis_tools_path }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8NoBOM -Append
+      run: |
+        [System.IO.File]::AppendAllText(
+          $env:GITHUB_PATH,
+          "${{ steps.ssis-tools.outputs.ssis_tools_path }}$([Environment]::NewLine)",
+          [System.Text.UTF8Encoding]::new($false)
+        )


### PR DESCRIPTION
Replace the utf8NoBOM Out-File usage with a cross-shell UTF-8 no-BOM append call so the action works when pwsh falls back to Windows PowerShell.