### PR TITLE
fix: install SSIS tools in runner temp

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -16,7 +16,31 @@ jobs:
         uses: actions/checkout@main
 
       - name: Setup SSIS tools
+        id: setup-ssis-tools
         uses: ./
+
+      - name: Assert SSIS tools output
+        shell: pwsh
+        run: |
+          $toolsPath = '${{ steps.setup-ssis-tools.outputs.ssis_tools_path }}'
+          if ([string]::IsNullOrWhiteSpace($toolsPath)) {
+            Write-Error 'Expected ssis_tools_path action output to be set.'
+            exit 1
+          }
+
+          $expectedRoot = Join-Path -Path '${{ runner.temp }}' -ChildPath 'setup-ssis-devops-tools'
+          if (-not $toolsPath.StartsWith($expectedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Error "Expected SSIS tools to be installed inside '$expectedRoot' but got '$toolsPath'."
+            exit 1
+          }
+
+          foreach ($expectedFile in 'SSISBuild.exe', 'SSISDeploy.exe') {
+            $expectedPath = Join-Path -Path $toolsPath -ChildPath $expectedFile
+            if (-not (Test-Path -LiteralPath $expectedPath)) {
+              Write-Error "Expected tool '$expectedFile' to exist at '$expectedPath'."
+              exit 1
+            }
+          }
 
       - name: Show SSISBuild.exe help
         run: SSISBuild.exe -h

--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ executables provided are:
 
 ```yaml
 - name: Setup SSIS devops tools
+  id: setup-ssis-tools
   uses: jonlabelle/setup-ssis-devops-tools@v1
+
+- name: Show installed location
+  shell: pwsh
+  run: |
+    Write-Host "SSIS tools path: ${{ steps.setup-ssis-tools.outputs.ssis_tools_path }}"
 ```
 
-After running this step, **SSISBuild.exe** and **SSISDeploy.exe** are available for use from your path.
+After running this step, **SSISBuild.exe** and **SSISDeploy.exe** are available from your job `PATH`.
+The tools are installed in the runner temp directory, and the resolved install location is also available through the `ssis_tools_path` output.
 
 See the [CI workflow](https://github.com/jonlabelle/setup-ssis-devops-tools/blob/main/.github/workflows/ci.yml) for example usage.
 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![CI](https://github.com/jonlabelle/setup-ssis-devops-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/jonlabelle/setup-ssis-devops-tools/actions/workflows/ci.yml)
 [![latest release](https://img.shields.io/github/v/tag/jonlabelle/setup-ssis-devops-tools.svg?label=version&sort=semver)](https://github.com/jonlabelle/setup-ssis-devops-tools/releases)
 
-> A GitHub action that installs the latest standalone SQL Server Integration
-> Service (SSIS) [devops tools](https://learn.microsoft.com/en-us/sql/integration-services/devops/ssis-devops-standalone).
+> A GitHub Action that installs the latest standalone SQL Server Integration
+> Services (SSIS) [DevOps Tools](https://learn.microsoft.com/en-us/sql/integration-services/devops/ssis-devops-standalone).
 
-Standalone SSIS DevOps Tools provide a set of executables to do SSIS CI/CD tasks
-without the dependency on the installation of Visual Studio or SSIS runtime. The
-executables provided are:
+Standalone SSIS DevOps Tools provide executables for SSIS CI/CD tasks without
+requiring Visual Studio or the SSIS runtime. This action makes the following
+tools available:
 
 - [SSISBuild.exe](https://learn.microsoft.com/en-us/sql/integration-services/devops/ssis-devops-standalone#ssisbuildexe): build SSIS projects in project deployment model or package deployment model.
 - [SSISDeploy.exe](https://learn.microsoft.com/en-us/sql/integration-services/devops/ssis-devops-standalone#ssisdeployexe): deploy ISPAC files to SSIS catalog, or DTSX files and their dependencies to file system.
@@ -19,20 +19,46 @@ executables provided are:
 > This action supports **Windows** runners only.
 
 ```yaml
-- name: Setup SSIS devops tools
-  id: setup-ssis-tools
-  uses: jonlabelle/setup-ssis-devops-tools@v1
+name: Use SSIS DevOps Tools
 
-- name: Show installed location
-  shell: pwsh
-  run: |
-    Write-Host "SSIS tools path: ${{ steps.setup-ssis-tools.outputs.ssis_tools_path }}"
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Setup SSIS DevOps Tools
+        id: setup-ssis-tools
+        uses: jonlabelle/setup-ssis-devops-tools@v1
+
+      - name: Show installed location
+        shell: pwsh
+        run: |
+          Write-Host "SSIS tools path: ${{ steps.setup-ssis-tools.outputs.ssis_tools_path }}"
+
+      - name: Show SSISBuild.exe help
+        shell: pwsh
+        run: SSISBuild.exe -h
 ```
 
-After running this step, **SSISBuild.exe** and **SSISDeploy.exe** are available from your job `PATH`.
-The tools are installed in the runner temp directory, and the resolved install location is also available through the `ssis_tools_path` output.
+After the setup step runs, **SSISBuild.exe** and **SSISDeploy.exe** are
+available from your job `PATH`.
 
-See the [CI workflow](https://github.com/jonlabelle/setup-ssis-devops-tools/blob/main/.github/workflows/ci.yml) for example usage.
+## Outputs
+
+| Name              | Description                                                          |
+| ----------------- | -------------------------------------------------------------------- |
+| `ssis_tools_path` | Directory where `SSISBuild.exe` and `SSISDeploy.exe` were installed. |
+
+## Behavior
+
+- Installs the tools under `${{ runner.temp }}/setup-ssis-devops-tools`.
+- Recreates the install directory on each run before extraction.
+- Adds the tools directory to the current job `PATH`.
+- Fails fast on non-Windows runners.
+
+See the [Windows test workflow](https://github.com/jonlabelle/setup-ssis-devops-tools/blob/main/.github/workflows/_test.yml) for a focused example and the [CI workflow](https://github.com/jonlabelle/setup-ssis-devops-tools/blob/main/.github/workflows/ci.yml) for full repository automation.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -23,15 +23,16 @@ runs:
       shell: pwsh
       id: paths
       run: |
+        $ErrorActionPreference = 'Stop'
         $rootPath = Join-Path -Path '${{ runner.temp }}' -ChildPath 'setup-ssis-devops-tools'
         $toolsPath = Join-Path -Path $rootPath -ChildPath 'ssis-tools'
         $installerPath = Join-Path -Path $rootPath -ChildPath 'SSISDevOpsTools.exe'
 
         if (Test-Path -LiteralPath $rootPath) {
-          Remove-Item -LiteralPath $rootPath -Recurse -Force
+          Remove-Item -LiteralPath $rootPath -Recurse -Force -ErrorAction Stop
         }
 
-        New-Item -Path $toolsPath -ItemType Directory -Force | Out-Null
+        New-Item -Path $toolsPath -ItemType Directory -Force -ErrorAction Stop | Out-Null
 
         [System.IO.File]::AppendAllText(
           $env:GITHUB_OUTPUT,
@@ -55,7 +56,8 @@ runs:
     - name: Extract SSISDevOpsTools.exe
       shell: pwsh
       run: |
-        & '${{ steps.paths.outputs.installer_path }}' /Q /C "/T:${{ steps.paths.outputs.ssis_tools_path }}"
+        $toolsPath = '${{ steps.paths.outputs.ssis_tools_path }}'
+        & '${{ steps.paths.outputs.installer_path }}' /Q /C "/T:`"$toolsPath`""
         if ($LastExitCode -ne 0) { exit $LastExitCode }
 
     - name: Verify SSIS tools installation

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,8 @@ runs:
       shell: pwsh
       run: |
         $toolsPath = '${{ steps.paths.outputs.ssis_tools_path }}'
-        & '${{ steps.paths.outputs.installer_path }}' /Q /C "/T:`"$toolsPath`""
+        $extractTargetArgument = "/T:$toolsPath"
+        & '${{ steps.paths.outputs.installer_path }}' /Q /C $extractTargetArgument
         if ($LastExitCode -ne 0) { exit $LastExitCode }
 
     - name: Verify SSIS tools installation

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ author: Jon LaBelle
 branding:
   icon: database
   color: yellow
+outputs:
+  ssis_tools_path:
+    description: Path where SSISBuild.exe and SSISDeploy.exe are installed
+    value: ${{ steps.paths.outputs.ssis_tools_path }}
 
 runs:
   using: composite
@@ -15,32 +19,68 @@ runs:
         echo "::error title=✘ Unsupported runner::Please choose a Windows runner to execute this action, e.g. windows-latest"
         exit 1
 
-    - name: Output SSIS tools path
+    - name: Prepare SSIS tools paths
       shell: pwsh
-      id: ssis-tools
+      id: paths
       run: |
-        $toolsPath = Join-Path -Path '${{ github.action_path }}' -ChildPath 'ssis-tools'
-        [System.IO.File]::AppendAllText($env:GITHUB_OUTPUT, "ssis_tools_path=$toolsPath$([Environment]::NewLine)", [System.Text.UTF8Encoding]::new($false))
+        $rootPath = Join-Path -Path '${{ runner.temp }}' -ChildPath 'setup-ssis-devops-tools'
+        $toolsPath = Join-Path -Path $rootPath -ChildPath 'ssis-tools'
+        $installerPath = Join-Path -Path $rootPath -ChildPath 'SSISDevOpsTools.exe'
+
+        if (Test-Path -LiteralPath $rootPath) {
+          Remove-Item -LiteralPath $rootPath -Recurse -Force
+        }
+
+        New-Item -Path $toolsPath -ItemType Directory -Force | Out-Null
+
+        [System.IO.File]::AppendAllText(
+          $env:GITHUB_OUTPUT,
+          "ssis_tools_path=$toolsPath$([Environment]::NewLine)",
+          [System.Text.UTF8Encoding]::new($false)
+        )
+        [System.IO.File]::AppendAllText(
+          $env:GITHUB_OUTPUT,
+          "installer_path=$installerPath$([Environment]::NewLine)",
+          [System.Text.UTF8Encoding]::new($false)
+        )
 
     - name: Download SSISDevOpsTools.exe
       shell: pwsh
       run: >-
         Invoke-WebRequest
         -Uri https://aka.ms/SSISDevOpsTools
-        -OutFile SSISDevOpsTools.exe
+        -OutFile '${{ steps.paths.outputs.installer_path }}'
         -ErrorAction 'Stop'
 
     - name: Extract SSISDevOpsTools.exe
       shell: pwsh
       run: |
-        .\SSISDevOpsTools.exe /Q /C "/T:${{ steps.ssis-tools.outputs.ssis_tools_path }}"
+        & '${{ steps.paths.outputs.installer_path }}' /Q /C "/T:${{ steps.paths.outputs.ssis_tools_path }}"
         if ($LastExitCode -ne 0) { exit $LastExitCode }
 
-    - name: Add SSIS tools path to system path
+    - name: Verify SSIS tools installation
+      shell: pwsh
+      run: |
+        $toolsPath = '${{ steps.paths.outputs.ssis_tools_path }}'
+        $missingFiles = @(
+          foreach ($expectedFile in 'SSISBuild.exe', 'SSISDeploy.exe') {
+            $expectedPath = Join-Path -Path $toolsPath -ChildPath $expectedFile
+            if (-not (Test-Path -LiteralPath $expectedPath)) {
+              $expectedFile
+            }
+          }
+        )
+
+        if ($missingFiles.Count -gt 0) {
+          Write-Error "Failed to find expected SSIS tools in '$toolsPath': $($missingFiles -join ', ')"
+          exit 1
+        }
+
+    - name: Add SSIS tools path to job PATH
       shell: pwsh
       run: |
         [System.IO.File]::AppendAllText(
           $env:GITHUB_PATH,
-          "${{ steps.ssis-tools.outputs.ssis_tools_path }}$([Environment]::NewLine)",
+          "${{ steps.paths.outputs.ssis_tools_path }}$([Environment]::NewLine)",
           [System.Text.UTF8Encoding]::new($false)
         )


### PR DESCRIPTION
Install SSIS DevOps Tools in the runner temp directory instead of the workspace and recreate the install folder on each run. Expose ssis_tools_path as an action output, verify the extracted executables before adding them to PATH, and update the README and Windows test workflow to match.