### PR TITLE
ci: add DevSkim security scanner workflow

### DIFF
--- a/.github/workflows/_devskim.yml
+++ b/.github/workflows/_devskim.yml
@@ -21,8 +21,10 @@ jobs:
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@main
+        continue-on-error: true
 
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@main
+        if: ${{ always() }}
         with:
           sarif_file: devskim-results.sarif

--- a/.github/workflows/_devskim.yml
+++ b/.github/workflows/_devskim.yml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: DevSkim
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  devskim:
+    name: DevSkim
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+
+      - name: Run DevSkim scanner
+        uses: microsoft/DevSkim-Action@main
+
+      - name: Upload DevSkim scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@main
+        with:
+          sarif_file: devskim-results.sarif

--- a/.github/workflows/_devskim.yml
+++ b/.github/workflows/_devskim.yml
@@ -1,5 +1,3 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-
 name: DevSkim
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
   devskim:
     name: DevSkim
     uses: ./.github/workflows/_devskim.yml
+    continue-on-error: true
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
   devskim:
     name: DevSkim
     uses: ./.github/workflows/_devskim.yml
-    continue-on-error: true
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 # Gated CI pipeline:
-#   Gate 1: Lint      - YAML, Markdown, Prettier   (parallel)
-#   Gate 2: Analyze   - PSScriptAnalyzer, Code QL  (needs: lint)
-#   Gate 3: Test      - Windows + non-Windows      (needs: analyze)
-#   Gate 4: Release   - Semantic release           (needs: test, push to main only)
+#   Gate 1: Lint        - YAML, Markdown, Prettier             (parallel)
+#   Gate 2: Analyze     - PSScriptAnalyzer (analyze-pwsh)      (needs: lint-yaml, lint-markdown, format-check)
+#   Gate 3: Test        - Windows + non-Windows                (needs: analyze-pwsh)
+#   Gate 4: Release     - Semantic release                     (needs: test, push to main only)
+#   Non-gating: CodeQL, DevSkim - Security analysis            (run independently)
 
 name: CI
 
@@ -52,6 +53,14 @@ jobs:
   codeql:
     name: CodeQL
     uses: ./.github/workflows/_codeql.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+  devskim:
+    name: DevSkim
+    uses: ./.github/workflows/_devskim.yml
     permissions:
       actions: read
       contents: read

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,5 @@
   "powershell.scriptAnalysis.settingsPath": "PSScriptAnalyzerSettings.psd1",
 
   // streetsidesoftware.code-spell-checker
-  "cSpell.words": ["commitlint", "jonlabelle", "SSIS"]
+  "cSpell.words": ["commitlint", "devskim", "jonlabelle", "SSIS"]
 }


### PR DESCRIPTION
Add the DevSkim security scanner as a non-gating workflow in the CI pipeline.

### Changes

- Add `_devskim.yml` reusable workflow using `microsoft/DevSkim-Action` with SARIF upload
- Wire `devskim` job into `ci.yml` as a non-gating security scan (runs independently)
- Update `ci.yml` header comment to document non-gating security analysis jobs
- Add `devskim` to cSpell dictionary